### PR TITLE
made offer/match secrets URL safe

### DIFF
--- a/src/donationswap.py
+++ b/src/donationswap.py
@@ -80,7 +80,9 @@ def admin_ajax(f):
 def create_secret():
 	timestamp_bytes = struct.pack('!d', time.time())
 	random_bytes = os.urandom(10)
-	return base64.b64encode(timestamp_bytes + random_bytes).decode('utf-8')
+	raw_secret = timestamp_bytes + random_bytes
+	secret = base64.b64encode(raw_secret, altchars=b'-_')
+	return secret.decode('utf-8')
 
 class DonationException(Exception):
 	pass

--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,7 @@ class BaseHandler(tornado.web.RequestHandler): # pylint: disable=abstract-method
 	def initialize(self, logic): # pylint: disable=arguments-differ
 		self.logic = logic # pylint: disable=attribute-defined-outside-init
 
-class CertbotHandler(BaseHandler): # pylint: disable=abstract-method
+class CertbotHandler(tornado.web.RequestHandler): # pylint: disable=abstract-method
 	'''
 	sudo certbot renew --webroot --webroot-path /srv/web/static/
 	'''
@@ -107,7 +107,7 @@ class HousekeepingHandler(BaseHandler): # pylint: disable=abstract-method
 				result = self.logic.clean_up()
 				self.set_status(200)
 				self.write(result)
-			except Exception as e:
+			except Exception as e: # pylint: disable=broad-except
 				self.set_status(500)
 				logging.error('Housekeeping Error', exc_info=True)
 				self.write(str(e))


### PR DESCRIPTION
This fixes a bug that was discovered during pen testing.

When a secret contains a + character, somewhere between our code putting it in the confirmation email and the user navigating to that URL, the + gets replaced with a whitespace. That's normal practice for URLs, but a bit unusual for hashes.

The standard practice is to replace the "+" and "/" that come out of base64 encoding with "-" and "_", respectively.

Note: It turns out we have a few offers with "+" in the secret, and all of them are confirmed, so it isn't a problem for all users. Still, if we can make our hashes URL safe, we should.