### PR TITLE
Config parameter for email "From" address.

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -31,6 +31,7 @@ class Config:
 		self.email_sender_name = data['email_sender_name']
 		self.email_smtp = data['email_smtp']
 		self.email_user = data['email_user']
+		self.email_from = data['email_from']
 		self.fixer_apikey = data['fixer_apikey']
 		self.geoip_datafile = data['geoip_datafile']
 		self.watchdog_email_password = data['watchdog_email_password']

--- a/src/donationswap.py
+++ b/src/donationswap.py
@@ -101,7 +101,7 @@ class Donationswap:
 		self._captcha = captcha.Captcha(self._config.captcha_secret)
 		self._currency = currency.Currency(self._config.currency_cache, self._config.fixer_apikey)
 		self._geoip = geoip.GeoIpCountry(self._config.geoip_datafile)
-		self._mail = mail.Mail(self._config.email_user, self._config.email_password, self._config.email_smtp, self._config.email_sender_name)
+		self._mail = mail.Mail(self._config.email_user, self._config.email_password, self._config.email_smtp, self._config.email_from, self._config.email_sender_name)
 
 		with self._database.connect() as db:
 			entities.load(db)

--- a/src/mail.py
+++ b/src/mail.py
@@ -8,11 +8,12 @@ import threading
 
 class Mail: # pylint: disable=too-few-public-methods
 
-	def __init__(self, user, password, smtp_host, sender_name=None):
+	def __init__(self, user, password, smtp_host, from_address, sender_name=None):
 		self._user = user
 		self._password = password
 		self._smtp_host = smtp_host
 		self._sender_name = sender_name
+		self._from_address = from_address
 
 	@staticmethod
 	def _populate(msg, key, value):
@@ -31,9 +32,9 @@ class Mail: # pylint: disable=too-few-public-methods
 			msg.attach(email.mime.text.MIMEText(html, 'html'))
 
 		if self._sender_name:
-			self._populate(msg, 'From', '%s <%s>' % (self._sender_name, self._user))
+			self._populate(msg, 'From', '%s <%s>' % (self._sender_name, self._from_address))
 		else:
-			self._populate(msg, 'From', self._user)
+			self._populate(msg, 'From', self._from_address)
 
 		self._populate(msg, 'Subject', subject)
 		self._populate(msg, 'To', to)

--- a/src/statsupdate.py
+++ b/src/statsupdate.py
@@ -14,7 +14,7 @@ CONFIG_FILENAME = '/srv/web/app-config.json'
 CONFIG = config.Config(CONFIG_FILENAME)
 
 def send_mail(msg, to, filename, data):
-	m = mail.Mail(CONFIG.email_user, CONFIG.email_password, CONFIG.email_smtp, CONFIG.email_sender_name)
+	m = mail.Mail(CONFIG.email_user, CONFIG.email_password, CONFIG.email_smtp, CONFIG.email_user, CONFIG.email_sender_name)
 
 	smtp_msg = m._prepare_msg('Donation Swap Stats Update', msg, msg, to, None, None)
 
@@ -58,4 +58,3 @@ if __name__ == "__main__":
 		CONFIG.contact_message_receivers['to'],
 		filename,
 		makeData(data))
-

--- a/src/watchdog.py
+++ b/src/watchdog.py
@@ -43,7 +43,7 @@ def _print_file_info(filename):
 def _send_mail(msg, to):
 	cfg = config.Config(CONFIG_FILENAME)
 	m = mail.Mail(cfg.watchdog_email_user, cfg.watchdog_email_password,
-	              cfg.watchdog_email_smtp, cfg.watchdog_email_sender_name)
+	              cfg.watchdog_email_smtp, cfg.watchdog_email_user, cfg.watchdog_email_sender_name)
 	m.send('Donation Swap Watchdog', msg, to=to, send_async=False)
 
 def check_backups():


### PR DESCRIPTION
We are now using a gmail account to sent the emails. Changing to sending emails from "eadonationswap@gmail.com" will help us prevent emails being treated as spam. Adding, and setting the "From" header to be the original address "donationswap@eahub.org" is required so that receivers don't get warning messages (in gmail client).